### PR TITLE
Removes deprecated extension: rebornix.Ruby

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,6 @@ Aliases
 - **[castwide.solargraph](https://marketplace.visualstudio.com/items?itemName=castwide.solargraph)** – Provides Ruby language server support, including code completion, linting, and inline documentation.
 - **[kaiwood.endwise](https://marketplace.visualstudio.com/items?itemName=kaiwood.endwise)** – Automatically inserts `end` statements in Ruby when writing conditionals, loops, and method definitions.
 - **[bung87.rails](https://marketplace.visualstudio.com/items?itemName=bung87.rails)** – Enhances Rails development in VS Code with navigation, model completion, and schema support.
-- **[rebornix.Ruby](https://marketplace.visualstudio.com/items?itemName=rebornix.Ruby)** – Provides basic Ruby language support, including syntax highlighting and debugging.
 
 ### JavaScript
 

--- a/config/vscode.sh
+++ b/config/vscode.sh
@@ -13,7 +13,6 @@ code --install-extension sorbet.sorbet-vscode-extension
 code --install-extension castwide.solargraph
 code --install-extension kaiwood.endwise
 code --install-extension bung87.rails
-code --install-extension rebornix.Ruby
 
 ####### Javascript extensions
 code --install-extension dbaeumer.vscode-eslint


### PR DESCRIPTION
## Description
The rebornix.Ruby extension has been deprecated. This PR removes it.
