### PR TITLE
When clicking links in iterm, set default editor to VScode

### DIFF
--- a/config/.zshrc
+++ b/config/.zshrc
@@ -88,6 +88,9 @@ source $ZSH/oh-my-zsh.sh
 #   export EDITOR='nvim'
 # fi
 
+export EDITOR="code --wait"
+export VISUAL="code --wait"
+
 # Compilation flags
 # export ARCHFLAGS="-arch $(uname -m)"
 


### PR DESCRIPTION
## Description
Updates zshrc file to set vscode as the default editor when clicking links within iterm